### PR TITLE
🧊 fix: replace "path" with "node:path"

### DIFF
--- a/templates/bun/.templates/api.ts
+++ b/templates/bun/.templates/api.ts
@@ -1,5 +1,5 @@
 import { createTemplate } from "milkio-template"
-import { join } from "path"
+import { join } from "node:path"
 
 await createTemplate(async (tools) => {
   return {

--- a/templates/bun/.templates/command.ts
+++ b/templates/bun/.templates/command.ts
@@ -1,5 +1,5 @@
 import { createTemplate } from "milkio-template"
-import { join } from "path"
+import { join } from "node:path"
 
 await createTemplate(async (tools) => {
   return {

--- a/templates/bun/.templates/use.ts
+++ b/templates/bun/.templates/use.ts
@@ -1,5 +1,5 @@
 import { createTemplate } from "milkio-template"
-import { join } from "path"
+import { join } from "node:path"
 
 await createTemplate(async (tools) => {
   return {


### PR DESCRIPTION
biome will emit an error, the Node.js builtin module should be imported with the node: protocol.